### PR TITLE
Add methods for PointFluxes and adapt magnetic fields to boundaries

### DIFF
--- a/docs/src/manual/hamiltonian.md
+++ b/docs/src/manual/hamiltonian.md
@@ -197,7 +197,9 @@ This adds a magnetic field in the Landau gauge to the Hamiltonian: ``\overrighta
 Here are all types of gauge fields supported by this package:
 - [`LandauGauge(B)`](@ref LandauGauge) — the Landau gauge, with the magnetic field `B` in the $z$ direction.
 - [`SymmetricGauge(B)`](@ref SymmetricGauge) — the symmetric gauge, with the magnetic field `B` in the $z$ direction.
-- [`PointFlux(Phi, center=(0, 0); gauge=:axial)`](@ref PointFlux) — a point flux in the point `center` with the flux `Phi`. The `gauge` argument can be either `:axial` (default) or `:singular`.
+- [`PointFlux(Phi, center=(0, 0); gauge=:axial)`](@ref PointFlux) — a point flux in the point `center` with the flux `Phi`. The `gauge` argument can be either `:axial` (default) or `:singular`:
+  - The `:axial` gauge stands for the vector potential ``\vec{\mathcal{A}} = \frac{\vec{\Phi} \times \vec{r}}{r}``.
+  - The `:singular` gauge is not described by any well-defined vector potential; here a particle acquires a phase factor only when it passes below the point flux.
 - [`PointFluxes(fluxes, points; gauge=:axial)`](@ref PointFluxes) — a collection of point fluxes. The `fluxes` is an array of fluxes (or a single flux for all points), and the `points` is an array of points described as `Tuple`s. Go to the type docstring to learn more; see also [`periodic_fluxes`](@ref) if you need periodic point fluxes in your system.
 - [`GaugeField(f; n)`](@ref GaugeField) — a general magnetic field. The `f` is a function that takes a coordinate vector and returns the vector potential ``\mathcal{A}`` at this point. The line integrals are calculated using the `n`-point trapezoidal rule. Note that the `n` must be set explicitly.
 - [`LineIntegralGaugeField(f)`](@ref LineIntegralGaugeField) — a general magnetic field. The `f` is a function that takes two coordinate vectors and returns the ``\int_{\vec{r}_1}^{\vec{r}_2} \mathcal{A} \cdot d\vec{r}`` line integral of the vector potential between these points.
@@ -223,7 +225,7 @@ LandauGauge(0.1) + SymmetricGauge(0.2) + PointFlux(0.3, (0.5, 0.5); gauge=:axial
 !!! warn
     Note that adding gauge fields together by `+` operator puts extra burden on the compiler. This allows extra performance when the number of the terms in the sum is small, but it can be very slow and cause compiler issues when it is large. In cases where you need a large sum of gauge fields, use more specific field types like `PointFluxes`, or consider creating your own custom field type.
 
-You can pass these objects using the `field` keyword argument to the `tightbinding_hamiltonian`, `construct_hamiltonian`, and `OperatorBuilder` functions to add the gauge field to the Hamiltonian:
+You can pass these objects using the `field` keyword argument to the `tightbinding_hamiltonian`, `construct_hamiltonian`, and `OperatorBuilder`/`FastOperatorBuilder` functions to add the gauge field to the Hamiltonian:
 
 ```@example 4
 builder = OperatorBuilder(l, auto_hermitian = true, field = LandauGauge(0.1) + PointFlux(0.3, (0.5, 0.5)))
@@ -236,5 +238,8 @@ end
 H2 = Hamiltonian(builder)
 H2 == tightbinding_hamiltonian(l, field=LandauGauge(0.1) + PointFlux(0.3, (0.5, 0.5)))
 ```
+
+!!! note
+    Most of the gauge fields are not directly compatible with periodic boundary conditions. Small tweaks are made to make them work automatically: for example, additional point fluxes are added to ensure hoppings are computed correctly, and the gauge is implicitly switched to `:singular`. You can disable this behavior by setting `auto_pbc_field=false` keyword argument if you really know what you are doing.
 
 To find out more about operators, diagonalization and observables, proceed to the next section.

--- a/src/core/boundaries.jl
+++ b/src/core/boundaries.jl
@@ -150,6 +150,7 @@ end
 adapt_boundaries(bcs::BoundaryConditions, l::AbstractLattice) =
     BoundaryConditions(map(b -> adapt_boundary(b, l), bcs.boundaries); depth=bcs.depth)
 getboundaries(l::AbstractLattice) = adapt_boundaries(getmeta(l, :boundaries, BoundaryConditions()), l)
+hasboundaries(l::AbstractLattice) = isempty(getboundaries(l).boundaries)
 
 function mappings(bcs::BoundaryConditions, site::AbstractSite)
     Base.Iterators.map(cartesian_indices(bcs)) do cind

--- a/src/core/boundaries.jl
+++ b/src/core/boundaries.jl
@@ -150,7 +150,7 @@ end
 adapt_boundaries(bcs::BoundaryConditions, l::AbstractLattice) =
     BoundaryConditions(map(b -> adapt_boundary(b, l), bcs.boundaries); depth=bcs.depth)
 getboundaries(l::AbstractLattice) = adapt_boundaries(getmeta(l, :boundaries, BoundaryConditions()), l)
-hasboundaries(l::AbstractLattice) = isempty(getboundaries(l).boundaries)
+hasboundaries(l::AbstractLattice) = !isempty(getboundaries(l).boundaries)
 
 function mappings(bcs::BoundaryConditions, site::AbstractSite)
     Base.Iterators.map(cartesian_indices(bcs)) do cind

--- a/src/operators/builder.jl
+++ b/src/operators/builder.jl
@@ -150,11 +150,12 @@ julia> H == tightbinding_hamiltonian(l, field=LandauGauge(0.1))
 true
 ```
 """
-function OperatorBuilder(T::Type{<:Number}, sys::SystemT;
-        field::FieldT=NoField(), auto_hermitian=false, occupations_type=nothing) where {SystemT<:System, FieldT<:AbstractField}
+function OperatorBuilder(T::Type{<:Number}, sys::SystemT; field::AbstractField=NoField(),
+        auto_hermitian=false, occupations_type=nothing) where {SystemT<:System}
     oneparticle_len = length(onebodybasis(sys))
+    field2 = adapt_field(field, lattice(sys))
     @assert occupations_type === nothing || occupations_type isa Type
-    OperatorBuilder{SystemT, occupations_type, FieldT, ArrayEntry{T}}(sys, field, internal_length(sys),
+    OperatorBuilder{SystemT, occupations_type, typeof(field2), ArrayEntry{T}}(sys, field2, internal_length(sys),
         SparseMatrixBuilder{ArrayEntry{T}}(oneparticle_len, oneparticle_len), auto_hermitian)
 end
 
@@ -167,11 +168,12 @@ uses a slightly faster internal representation of the operator matrix, but only 
 increment/decrement assignments:
 `builder[site1, site2] += 1` is allowed, but `builder[site1, site2] = 1` is not.
 """
-function FastOperatorBuilder(T::Type{<:Number}, sys::SystemT;
-    field::FieldT=NoField(), auto_hermitian=false, occupations_type=nothing) where {SystemT<:System, FieldT<:AbstractField}
+function FastOperatorBuilder(T::Type{<:Number}, sys::SystemT; field::AbstractField=NoField(),
+        auto_hermitian=false, occupations_type=nothing) where {SystemT<:System}
     oneparticle_len = length(onebodybasis(sys))
+    field2 = adapt_field(field, lattice(sys))
     @assert occupations_type === nothing || occupations_type isa Type
-    OperatorBuilder{SystemT, occupations_type, FieldT, T}(sys, field, internal_length(sys),
+    OperatorBuilder{SystemT, occupations_type, typeof(field2), T}(sys, field2, internal_length(sys),
         SparseMatrixBuilder{T}(oneparticle_len, oneparticle_len), auto_hermitian)
 end
 @accepts_system_t OperatorBuilder

--- a/src/operators/constructoperator.jl
+++ b/src/operators/constructoperator.jl
@@ -84,7 +84,7 @@ function arg_to_pair(sample::Sample, arg::Pair{<:Union{Number,AbstractMatrix,Dat
 end
 
 """
-    construct_operator([T, ]sys, terms...[; field])
+    construct_operator([T, ]sys, terms...[; field, auto_pbc_field])
     construct_operator([T, ]lat[, internal, terms...; field])
 
 Construct an operator for the given system.
@@ -108,6 +108,8 @@ See documentation for more details.
 
 ## Keyword Arguments
 - `field`: The gauge field to use for the bond operators. Default is `NoField()`.
+- `auto_pbc_field`: Whether to automatically adapt the field to the periodic boundary
+    conditions of the lattice. Defaults to `true`.
 """
 function construct_operator(T::Type, sys::System, args...; kw...)
     sample = sys.sample
@@ -123,8 +125,8 @@ end
 @accepts_system_t construct_operator
 
 """
-    construct_hamiltonian([T, ]sys, terms...[; field])
-    construct_hamiltonian([T, ]lat[, internal, terms...; field])
+    construct_hamiltonian([T, ]sys, terms...[; field, auto_pbc_field])
+    construct_hamiltonian([T, ]lat[, internal, terms...; field, auto_pbc_field])
 
 Construct a Hamiltonian for the given system. Does the same as `construct_operator`, but wraps
 the result in a `Hamiltonian` type.
@@ -134,8 +136,8 @@ construct_hamiltonian(T::Type, sys::System, args...; kw...) =
 @accepts_system_t construct_hamiltonian
 
 """
-    tightbinding_hamiltonian([T, ]sys[, args...; t1=1, t2=0, t3=0, field])
-    tightbinding_hamiltonian([T, ]lat[, internal, args...; t1=1, t2=0, t3=0, field])
+    tightbinding_hamiltonian([T, ]sys[, args...; t1=1, t2=0, t3=0, field, auto_pbc_field])
+    tightbinding_hamiltonian([T, ]lat[, internal, args...; t1=1, t2=0, t3=0, field, auto_pbc_field])
 
 Construct a tight-binding Hamiltonian for the given system.
 
@@ -150,6 +152,8 @@ All other arguments are interpreted as terms of the Hamiltonian and passed to `c
 - `t1`, `t2`, `t3`: The hopping amplitudes for the nearest, next-nearest, and next-next-nearest
     neighbors, respectively.
 - `field`: The gauge field to use for the bond operators. Default is `NoField()`.
+- `auto_pbc_field`: Whether to automatically adapt the field to the periodic boundary
+    conditions of the lattice. Defaults to `true`.
 """
 tightbinding_hamiltonian(T::Type, sys::System, args...; t1=1, t2=0, t3=0, kw...) =
     construct_hamiltonian(T, sys, args...,

--- a/src/operators/magneticfield.jl
+++ b/src/operators/magneticfield.jl
@@ -1,6 +1,7 @@
 import Base: +, *
 using LinearAlgebra, StaticArrays, Logging
 abstract type AbstractField end
+adapt_field(fld::AbstractField, ::AbstractLattice) = fld
 
 """
     vector_potential(field, point)
@@ -117,3 +118,4 @@ function Base.add_sum(f1::FieldSum{<:NTuple{32}}, f2::AbstractField)
     return f1 + f2
 end
 +(f1::AbstractField, f2::AbstractField) = FieldSum((_fldterms(f1)..., _fldterms(f2)...))
+adapt_field(f::FieldSum, l::AbstractLattice) = FieldSum(adapt_field.(f.fields, Ref(l)))

--- a/src/zoo/magneticfields.jl
+++ b/src/zoo/magneticfields.jl
@@ -238,12 +238,12 @@ function adapt_field(field::PointFluxes, lat::AbstractLattice)
     !hasboundaries(lat) && return field
     _fluxgauge(field) === :singular ||
         @warn "Setting flux gauge to singular for a lattice with periodic boundary conditions"
-    if dims(lat) == 2
+    if dims(lat) != 2
         @warn "Only 2D lattices support periodic fluxes; skipping flux position adjustment"
         return field
     end
     bcs = getboundaries(lat)
-    new_field = PointFluxes{:singular}()
+    new_field = PointFluxes{:singular}([], [])
     for cind in cartesian_indices(lat)
         tup = Tuple(cind)
 

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -77,6 +77,25 @@ import LatticeModels: line_integral
         end
     end
 
+    @testset "Fluxes and boundaries" begin
+        lnb = SquareLattice(5, 5)
+        lwb = setboundaries(lnb, :axis1 => true, :axis2 => true)
+
+        flx = PointFlux(0.1, (0.5, 0.5), gauge=:singular)
+        flxs = periodic_fluxes(lnb, flx)
+        flxs2 = periodic_fluxes(lwb, flx)
+        @test flxs.points == flxs2.points
+
+        flx_adn = LatticeModels.adapt_field(flx, lnb)
+        flxs_adn = LatticeModels.adapt_field(flxs, lnb)
+        flx_adw = LatticeModels.adapt_field(flx, lwb)
+        flxs_adw = LatticeModels.adapt_field(flxs, lwb)
+        @test flx_adn isa PointFlux
+        @test length(flxs_adn.points) == 25
+        @test length(flx_adw.points) == 9
+        @test length(flxs_adw.points) == 9 * 25
+    end
+
     @testset "Field application" begin
         H1 = construct_operator(l, BravaisTranslation(axis=1), BravaisTranslation(axis=2), field = la)
         H2 = construct_operator(l, BravaisTranslation(axis=1), BravaisTranslation(axis=2), field = lla)

--- a/test/test_field.jl
+++ b/test/test_field.jl
@@ -58,6 +58,13 @@ import LatticeModels: line_integral
         @test line_integral(ps1, p1, p2) ≈ 0.2 atol = 1e-8
         @test line_integral(ps2, p1, p2) ≈ 0.2 atol = 1e-8
 
+        bf1 = PointFluxes()
+        push!(bf1, PointFlux(0.1, (1, 2)), PointFlux(0.1, (3, 4)))
+        bf2 = PointFluxes()
+        append!(bf2, ps3)
+        @test line_integral(bf1, p1, p2) ≈ line_integral(ps3, p1, p2) atol = 1e-8
+        @test line_integral(bf2, p1, p2) ≈ line_integral(ps3, p1, p2) atol = 1e-8
+
         ppfs1 = periodic_fluxes(l, PointFlux(0.1, (0.4, 0.4)))
         ppfs2 = periodic_fluxes(l, PointFlux(0.1, (1.4, 0.4)))
         ppfs3 = PointFluxes(0.1, l, offset=(0.4, 0.4))


### PR DESCRIPTION
This PR implements an internal `adapt_field` function to adjust magnetic fields according to boundary conditions (See #15).

It dispatches on field and lattice type. Currently the only thing it does is adding extra point fluxes in case of PBC to make sure they are correctly handled in "over-edge" hoppings.