### PR TITLE
Interaction & occupation types

### DIFF
--- a/docs/src/manual/hamiltonian.md
+++ b/docs/src/manual/hamiltonian.md
@@ -1,6 +1,8 @@
 # Systems and Hamiltonians
 
-This section describes how to define the Hamiltonian of a system. The system, in this context, is a lattice, a basis describing on-site degrees of freedom, and some additional parameters like temperature or chemical potential.
+This section describes how to define the Hamiltonian of a system. The system, in this context, is a lattice, a basis describing on-site degrees of freedom, and some additional parameters like temperature or chemical potential. The Hamiltonian, in turn, is just an operator that keeps all the information about the system.
+
+There are several models and Hamiltonians shipped with this package: check out [Built-in models](@ref) section of the API docs for more. But in this section, we will focus on how to create the Hamiltonian from the ground up.
 
 ## Defining the system
 
@@ -34,6 +36,8 @@ lines are equivalent to the previous example:
 H = tightbinding_hamiltonian(l, SpinBasis(1//2))
 P = densitymatrix(H, μ = 0, T = 1, info = false)
 ```
+
+For manybody computations you may find interesting [`NParticles`](@ref), if the number of particles is fixed, or you can use `System(mb_basis[; T])` for any many-body basis `mb_basis` to define the system.
 
 ## Basic tight-binding Hamiltonian
 

--- a/src/LatticeModels.jl
+++ b/src/LatticeModels.jl
@@ -74,7 +74,7 @@ export scalefactor, shaperadius, fillshapes, addshapes!, deleteshapes!, removeda
 include("zoo/magneticfields.jl")
 export LandauGauge, SymmetricGauge, PointFlux, PointFluxes, periodic_fluxes
 include("zoo/models.jl")
-export hubbard, bosehubbard, fermihubbard, qwz, haldane, kanemele
+export FermiHubbardSpinSystem, hubbard, bosehubbard, fermihubbard, qwz, haldane, kanemele
 include("zoo/currents.jl")
 export DensityCurrents, LocalOperatorCurrents
 

--- a/src/operators/builder.jl
+++ b/src/operators/builder.jl
@@ -92,7 +92,7 @@ end
 A helper struct for building custom operators. This struct is used to build operators for a
 given system or lattice.
 """
-struct OperatorBuilder{SystemT, OccT, FieldT, T}
+struct OperatorBuilder{SystemT, FieldT, T}
     sys::SystemT
     field::FieldT
     internal_length::Int
@@ -101,8 +101,8 @@ struct OperatorBuilder{SystemT, OccT, FieldT, T}
 end
 
 """
-    OperatorBuilder([T, ]sys, [; field, auto_hermitian, auto_pbc_field, occupations_type])
-    OperatorBuilder([T, ]lat, [internal; field, auto_hermitian, occupations_type])
+    OperatorBuilder([T, ]sys, [; field, auto_hermitian, auto_pbc_field])
+    OperatorBuilder([T, ]lat, [internal; field, auto_hermitian])
 
 Construct an `OperatorBuilder` for a given system or lattice.
 
@@ -119,9 +119,6 @@ Construct an `OperatorBuilder` for a given system or lattice.
     Defaults to `false`.
 - `auto_pbc_field`: Whether to automatically adapt the field to the periodic boundary
     conditions of the lattice. Defaults to `true`.
-- `occupations_type`: The occupations type for the many-body operator. Ignored for one-body
-    operators. By default, the occupation numbers are stored in vectors, but you can use,
-    for example, set it to `FermionBitstring`s for better performance on fermion systems.
 
 ## Example
 ```jldoctest
@@ -154,21 +151,20 @@ true
 ```
 """
 function OperatorBuilder(T::Type{<:Number}, sys::SystemT; field::AbstractField=NoField(),
-        auto_hermitian=false, auto_pbc_field=true, occupations_type=nothing) where {SystemT<:System}
+        auto_hermitian=false, auto_pbc_field=true) where {SystemT<:System}
     oneparticle_len = length(onebodybasis(sys))
     if auto_pbc_field
         field2 = adapt_field(field, lattice(sys))
     else
         field2 = field
     end
-    @assert occupations_type === nothing || occupations_type isa Type
-    OperatorBuilder{SystemT, occupations_type, typeof(field2), ArrayEntry{T}}(sys, field2, internal_length(sys),
+    OperatorBuilder{SystemT, typeof(field2), ArrayEntry{T}}(sys, field2, internal_length(sys),
         SparseMatrixBuilder{ArrayEntry{T}}(oneparticle_len, oneparticle_len), auto_hermitian)
 end
 
 """
-    FastOperatorBuilder([T, ]sys, [; field, auto_hermitian, occupations_type])
-    FastOperatorBuilder([T, ]lat, [internal; field, auto_hermitian, occupations_type])
+    FastOperatorBuilder([T, ]sys, [; field, auto_hermitian])
+    FastOperatorBuilder([T, ]lat, [internal; field, auto_hermitian])
 
 Construct an `OperatorBuilder` for a given system or lattice. This version of the constructor
 uses a slightly faster internal representation of the operator matrix, but only allows
@@ -176,15 +172,14 @@ increment/decrement assignments:
 `builder[site1, site2] += 1` is allowed, but `builder[site1, site2] = 1` is not.
 """
 function FastOperatorBuilder(T::Type{<:Number}, sys::SystemT; field::AbstractField=NoField(),
-        auto_hermitian=false, auto_pbc_field=true, occupations_type=nothing) where {SystemT<:System}
+        auto_hermitian=false, auto_pbc_field=true) where {SystemT<:System}
     oneparticle_len = length(onebodybasis(sys))
     if auto_pbc_field
         field2 = adapt_field(field, lattice(sys))
     else
         field2 = field
     end
-    @assert occupations_type === nothing || occupations_type isa Type
-    OperatorBuilder{SystemT, occupations_type, typeof(field2), T}(sys, field2, internal_length(sys),
+    OperatorBuilder{SystemT, typeof(field2), T}(sys, field2, internal_length(sys),
         SparseMatrixBuilder{T}(oneparticle_len, oneparticle_len), auto_hermitian)
 end
 @accepts_system_t OperatorBuilder
@@ -194,7 +189,7 @@ sample(opb::OperatorBuilder) = sample(opb.sys)
 const OpBuilderWithInternal = OperatorBuilder{<:System{<:SampleWithInternal}}
 const OpBuilderWithoutInternal = OperatorBuilder{<:System{<:SampleWithoutInternal}}
 
-function Base.show(io::IO, mime::MIME"text/plain", opb::OperatorBuilder{Sys,OccT,Field,T}) where {Sys,OccT,Field,T}
+function Base.show(io::IO, mime::MIME"text/plain", opb::OperatorBuilder{Sys,Field,T}) where {Sys,Field,T}
     print(io, "OperatorBuilder(",
     opb.field == NoField() ? "" : "field=$(opb.field), ",
     "auto_hermitian=$(opb.auto_hermitian))\nSystem: ")
@@ -259,17 +254,17 @@ Base.@propagate_inbounds function Base.setindex!(opbuilder::OperatorBuilder, rhs
     return nothing
 end
 
-function _construct_manybody_maybe(occupations_type, sys::ManyBodySystem, op::AbstractOperator)
+function _construct_manybody_maybe(sys::ManyBodySystem, op::AbstractOperator)
     bas = basis(op)
     check_samebases(bas, onebodybasis(sys))
-    return manybodyoperator(ManyBodyBasis(bas, occupations(sys, occupations_type)), op)
+    return manybodyoperator(ManyBodyBasis(bas, occupations(sys)), op)
 end
-_construct_manybody_maybe(::Any, ::OneParticleBasisSystem, op::AbstractOperator) = op
-function QuantumOpticsBase.Operator(opb::OperatorBuilder{<:Any, OccT}; warning=true) where OccT
+_construct_manybody_maybe(::OneParticleBasisSystem, op::AbstractOperator) = op
+function QuantumOpticsBase.Operator(opb::OperatorBuilder{<:Any}; warning=true)
     op = Operator(onebodybasis(opb.sys), to_matrix(opb.mat_builder))
     if warning && !opb.auto_hermitian && !ishermitian(op)
         @warn "The resulting operator is not hermitian. Set `warning=false` to hide this message or add `auto_hermitian=true` to the `OperatorBuilder` constructor."
     end
-    return _construct_manybody_maybe(OccT, opb.sys, op)
+    return _construct_manybody_maybe(opb.sys, op)
 end
 Hamiltonian(opb::OperatorBuilder; kw...) = Hamiltonian(opb.sys, Operator(opb; kw...))

--- a/src/operators/builder.jl
+++ b/src/operators/builder.jl
@@ -120,7 +120,8 @@ Construct an `OperatorBuilder` for a given system or lattice.
 - `auto_pbc_field`: Whether to automatically adapt the field to the periodic boundary
     conditions of the lattice. Defaults to `true`.
 - `occupations_type`: The occupations type for the many-body operator. Ignored for one-body
-    operators. By default, the occupation numbers are stored in vectors.
+    operators. By default, the occupation numbers are stored in vectors, but you can use,
+    for example, set it to `FermionBitstring`s for better performance on fermion systems.
 
 ## Example
 ```jldoctest

--- a/src/operators/manybody.jl
+++ b/src/operators/manybody.jl
@@ -30,6 +30,7 @@ function _2p_interaction_diags(M::AbstractMatrix, occups, N::Int)
             occi = _count_onsite(occ, i, N)
             occi == 0 && continue
             for j in 1:i - 1
+                M[i, j] == 0 && continue
                 occj = _count_onsite(occ, j, N)
                 occj == 0 && continue
                 int_energy += M[i, j] * occi * occj

--- a/src/operators/manybody.jl
+++ b/src/operators/manybody.jl
@@ -56,18 +56,17 @@ function interaction(f::Function, T::Type{<:Number}, sys::NParticles; occupation
 end
 
 """
-    interaction(f, [T, ]sys, K[; affect_internal=true])
+    interaction(f, [T, ]sys, K)
 
 Create an `2K`-site interaction operator for a given `NParticles` system. The function `f`
 takes two `K`-tuples of integer numbers, which are site indices for creation and annihilation
 operators, and returns the interaction energy.
 
-If `affect_internal` is `true` (default), the interaction operator will act on the internal
-degrees of freedom as well, and `f` will take four `K`-tuples — lattice and internal indices for
-creation and annihilation operators. If the system has no internal degrees of freedom,
-`affect_internal` will automatically be set to `false` and `f` will take two `K`-tuples.
+If the system `sys` has internal degrees of freedom, the function `f` should take four `K`-tuples:
+first two are site & internal indices for creation operators, and the last two are the same for
+annihilation operators.
 """
-function interaction(f::Function, T::Type{<:Number}, sys::NParticles, ::Val{K}; affect_internal=true) where K
+function interaction(f::Function, T::Type{<:Number}, sys::NParticles, ::Val{K}) where K
     # This function uses undocumented QuantumOpticsBase API. Be careful!
     @assert K ≤ sys.nparticles
     l = lattice(sys)

--- a/src/operators/system.jl
+++ b/src/operators/system.jl
@@ -269,6 +269,7 @@ julia> mbas = ManyBodyBasis(bas, fermionstates(bas, 2));
 
 julia> System(mbas, T=2)
 Many-body system on (9-site SquareLattice in 2D space) ⊗ Spin(1/2) (153 states, T=2.0)
+```
 """
 System(mb::ManyBodyBasis; T=0) = ManyBodyBasisSystem(mb; T=T)
 _occtype(::NParticles{OccT}) where {OccT} = OccT

--- a/src/operators/system.jl
+++ b/src/operators/system.jl
@@ -191,7 +191,7 @@ end
 function Base.show(io::IO, mime::MIME"text/plain", sys::ManyBodyBasisSystem)
     print(io, "Many-body system on ")
     show(io, mime, sys.sample)
-    print(io, " ($(length(sys.mb)) states)")
+    print(io, " ($(length(sys.mb)) states, T=$(sys.T))")
 end
 function Base.union(mbs1::ManyBodyBasisSystem, mbs2::ManyBodyBasisSystem)
     sample(mbs1) == sample(mbs2) || throw(ArgumentError("Incompatible systems"))
@@ -248,6 +248,28 @@ function System(args...; μ = nothing, mu = μ, N = nothing, statistics=FermiDir
     isempty(kw) || throw(ArgumentError("Unsupported keyword arguments " * join(keys(kw), ", ")))
     System(Sample(args...), mu=mu, N=N, T=T, statistics=statistics)
 end
+
+"""
+    System(mb[; T])
+
+Create a system with a given many-body basis `mb`.
+
+This function is used to create a many-body system from an arbitrary many-body basis with a
+lattice.
+
+## Example
+```jldoctest
+julia> using LatticeModels
+
+julia> lat = SquareLattice(3, 3);
+
+julia> bas = SpinBasis(1//2) ⊗ LatticeBasis(lat);
+
+julia> mbas = ManyBodyBasis(bas, fermionstates(bas, 2));
+
+julia> System(mbas, T=2)
+Many-body system on (9-site SquareLattice in 2D space) ⊗ Spin(1/2) (153 states, T=2.0)
+"""
 System(mb::ManyBodyBasis; T=0) = ManyBodyBasisSystem(mb; T=T)
 _occtype(::NParticles{OccT}) where {OccT} = OccT
 function occupations(np::NParticles, occupations_type::Union{Type,Nothing}=_occtype(np))

--- a/src/operators/system.jl
+++ b/src/operators/system.jl
@@ -248,7 +248,7 @@ function System(args...; μ = nothing, mu = μ, N = nothing, statistics=FermiDir
     isempty(kw) || throw(ArgumentError("Unsupported keyword arguments " * join(keys(kw), ", ")))
     System(Sample(args...), mu=mu, N=N, T=T, statistics=statistics)
 end
-System(mb::ManyBodyBasis; T=0) = ManyBodyBasisSystem(mb, T)
+System(mb::ManyBodyBasis; T=0) = ManyBodyBasisSystem(mb; T=T)
 _occtype(::NParticles{OccT}) where {OccT} = OccT
 function occupations(np::NParticles, occupations_type::Union{Type,Nothing}=_occtype(np))
     n = np.nparticles

--- a/src/zoo/models.jl
+++ b/src/zoo/models.jl
@@ -11,8 +11,7 @@ function hubbard(T::Type, sys::NParticles, args...; U::Real=0, kw...)
         No interaction is possible."""
     end
     op = Operator(tightbinding_hamiltonian(T, sys, args...; kw...)) +
-        interaction((site1, site2) -> (site1 == site2 ? U : zero(U)), T, sys,
-            occupations_type = get(kw, :occupations_type, nothing))
+        interaction((site1, site2) -> (site1 == site2 ? U : zero(U)), T, sys)
     return Hamiltonian(sys, op)
 end
 """
@@ -34,8 +33,8 @@ Generates a Bose-Hubbard model hamiltonian on given lattice `lat`.
 - `T`: The temperature of the system. Default is zero.
 - `field`: The magnetic field. Default is `NoField()`.
 """
-bosehubbard(type::Type, l::AbstractLattice, N::Int; T = 0, kw...) =
-    hubbard(type, NParticles(l, N; T = T, statistics = BoseEinstein); kw...)
+bosehubbard(type::Type, l::AbstractLattice, N::Int; T = 0, occupations_type=nothing, kw...) =
+    hubbard(type, NParticles(l, N; T = T, statistics = BoseEinstein, occupations_type=occupations_type); kw...)
 """
     fermihubbard([type, ]lat, N[; U, T, t1, t2, t3, field])
 
@@ -56,8 +55,8 @@ Generates a Fermi-Hubbard model hamiltonian on given lattice `lat`.
 - `T`: The temperature of the system. Default is zero.
 - `field`: The magnetic field. Default is `NoField()`.
 """
-fermihubbard(type::Type, l::AbstractLattice, N::Int; T = 0, kw...) =
-    hubbard(type, NParticles(l ⊗ SpinBasis(1//2), N; T = T, statistics = FermiDirac); kw...)
+fermihubbard(type::Type, l::AbstractLattice, N::Int; T = 0, occupations_type=nothing, kw...) =
+    hubbard(type, NParticles(l ⊗ SpinBasis(1//2), N; T = T, statistics = FermiDirac, occupations_type=occupations_type); kw...)
 @accepts_t hubbard
 @accepts_t bosehubbard
 @accepts_t fermihubbard

--- a/src/zoo/models.jl
+++ b/src/zoo/models.jl
@@ -10,8 +10,10 @@ function hubbard(T::Type, sys::NParticles, args...; U::Real=0, kw...)
         @warn """Fermi-Dirac statistics with no internal degrees of freedom.
         No interaction is possible."""
     end
-    return tightbinding_hamiltonian(T, sys, args...; kw...) +
-        interaction((site1, site2) -> (site1 == site2 ? U : zero(U)), T, sys)
+    op = Operator(tightbinding_hamiltonian(T, sys, args...; kw...)) +
+        interaction((site1, site2) -> (site1 == site2 ? U : zero(U)), T, sys,
+            occupations_type = get(kw, :occupations_type, nothing))
+    return Hamiltonian(sys, op)
 end
 """
     bosehubbard([type, ]lat, N[; U, T, t1, t2, t3, field])

--- a/src/zoo/models.jl
+++ b/src/zoo/models.jl
@@ -53,14 +53,14 @@ end
 function _filter_occupations!(occ::AbstractVector, N_up, N_down)
     keep_inds = Int[]
     for i in eachindex(occ)
-        if _nspins(occ[i]) == N_up && _nspins(occ[i], false) == N_down
+        if _nspins(occ[i]) != N_up || _nspins(occ[i], false) != N_down
             push!(keep_inds, i)
         end
     end
     if occ isa QuantumOpticsBase.SortedVector
-        keepat!(occ.sortedvector, keep_inds)
+        deleteat!(occ.sortedvector, keep_inds)
     else
-        keepat!(occ, keep_inds)
+        deleteat!(occ, keep_inds)
     end
 end
 

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -29,6 +29,9 @@ import LatticeModels: ManyBodyBasis, FermionBitstring
         Hmb = qwz(NParticles(small_l, spin, 2))
         Hmb2 = qwz(NParticles(small_l, spin, 2), occupations_type=FermionBitstring)
         @test Hmb.data == Hmb2.data
+        Hub = fermihubbard(small_l, 3, U = 1)
+        Hub2 = fermihubbard(small_l, 3, U = 1, occupations_type=FermionBitstring)
+        @test Hub.data == Hub2.data
 
         # Check localexpect
         @test localdensity(P) ≈ localexpect(one(spin), P)

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -27,7 +27,7 @@ import LatticeModels: ManyBodyBasis, FermionBitstring
         # Check occupation types
         small_l = SquareLattice(3, 3)
         Hmb = qwz(NParticles(small_l, spin, 2))
-        Hmb2 = qwz(NParticles(small_l, spin, 2), occupations_type=FermionBitstring)
+        Hmb2 = qwz(NParticles(small_l, spin, 2, occupations_type=FermionBitstring))
         @test Hmb.data == Hmb2.data
         Hub = fermihubbard(small_l, 3, U = 1)
         Hub2 = fermihubbard(small_l, 3, U = 1, occupations_type=FermionBitstring)

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -24,26 +24,9 @@ import LatticeModels: ManyBodyBasis, FermionBitstring
         P = @test_logs (:info, """Creating density matrix: FermiDirac distribution, T = 0.0, μ = 0
         set `info=false` to disable this message""") densitymatrix(H_0, statistics=FermiDirac)
 
-        # Check occupation types
-        small_l = SquareLattice(3, 3)
-        Hmb = qwz(NParticles(small_l, spin, 2))
-        Hmb2 = qwz(NParticles(small_l, spin, 2, occupations_type=FermionBitstring))
-        @test Hmb.data == Hmb2.data
-        Hub = fermihubbard(small_l, 3, U = 1)
-        Hub2 = fermihubbard(small_l, 3, U = 1, occupations_type=FermionBitstring)
-        @test Hub.data == Hub2.data
-        Huud = hubbard(FermiHubbardSpinSystem(small_l, 2, 2))
-        Huud2 = hubbard(FermiHubbardSpinSystem(small_l, 2, 2, occupations_type=FermionBitstring))
-        @test Huud.data == Huud2.data
-        @test length(basis(Huud)) == binomial(length(small_l), 2) ^ 2
-
-        sys1 = FermiHubbardSpinSystem(small_l, 0, 1)
-        sys2 = FermiHubbardSpinSystem(small_l, 1, 0)
-        sys3 = NParticles(small_l ⊗ spin, 1, statistics=FermiDirac)
-        @test basis(union(sys1, sys2)) == basis(sys3)
-
         # Check localexpect
         @test localdensity(P) ≈ localexpect(one(spin), P)
+        Hmb = qwz(NParticles(SquareLattice(3, 3), spin, 2))
         Pmb = densitymatrix(Hmb, info=false)
         @test localdensity(Pmb) ≈ localexpect(one(spin), Pmb)
         @test_throws ArgumentError localexpect(one(spin), ptrace(P, :internal))
@@ -150,7 +133,7 @@ import LatticeModels: ManyBodyBasis, FermionBitstring
         @test destroy(sys, site2) == destroy(mbb, 25)
     end
 
-    @testset "Interaction" begin
+    @testset "Manybody" begin
         l = SquareLattice(2, 2)
         # Bose-Hubbard interaction
         sys = NParticles(l, 3, statistics=BoseEinstein)
@@ -183,6 +166,27 @@ import LatticeModels: ManyBodyBasis, FermionBitstring
         H2 = bosehubbard(l, 2)
         d2 = localdensity(groundstate(H2))
         @test d1.values * 2 ≈ d2.values
+
+        # Check occupation types
+        small_l = SquareLattice(3, 3)
+        spin = SpinBasis(1//2)
+
+        Hmb = qwz(NParticles(small_l, spin, 2))
+        Hmb2 = qwz(NParticles(small_l, spin, 2, occupations_type=FermionBitstring))
+        @test Hmb.data == Hmb2.data
+        Hub = fermihubbard(small_l, 3, U = 1)
+        Hub2 = fermihubbard(small_l, 3, U = 1, occupations_type=FermionBitstring)
+        @test Hub.data == Hub2.data
+        Huud = hubbard(FermiHubbardSpinSystem(small_l, 2, 2), U = 1)
+        Huud2 = hubbard(FermiHubbardSpinSystem(small_l, 2, 2,
+            occupations_type=FermionBitstring{BigInt}), U = 1)
+        @test Huud.data == Huud2.data
+        @test length(basis(Huud)) == binomial(length(small_l), 2) ^ 2
+
+        sys1 = FermiHubbardSpinSystem(small_l, 0, 1)
+        sys2 = FermiHubbardSpinSystem(small_l, 1, 0)
+        sys3 = NParticles(small_l ⊗ spin, 1, statistics=FermiDirac)
+        @test basis(union(sys1, sys2)) == basis(sys3)
     end
 
     @testset "Diagonalize" begin

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -32,6 +32,15 @@ import LatticeModels: ManyBodyBasis, FermionBitstring
         Hub = fermihubbard(small_l, 3, U = 1)
         Hub2 = fermihubbard(small_l, 3, U = 1, occupations_type=FermionBitstring)
         @test Hub.data == Hub2.data
+        Huud = hubbard(FermiHubbardSpinSystem(small_l, 2, 2))
+        Huud2 = hubbard(FermiHubbardSpinSystem(small_l, 2, 2, occupations_type=FermionBitstring))
+        @test Huud.data == Huud2.data
+        @test length(basis(Huud)) == binomial(length(small_l), 2) ^ 2
+
+        sys1 = FermiHubbardSpinSystem(small_l, 0, 1)
+        sys2 = FermiHubbardSpinSystem(small_l, 1, 0)
+        sys3 = NParticles(small_l ⊗ spin, 1, statistics=FermiDirac)
+        @test basis(union(sys1, sys2)) == basis(sys3)
 
         # Check localexpect
         @test localdensity(P) ≈ localexpect(one(spin), P)


### PR DESCRIPTION
Due to `interaction` not supporting different occupation types, models like `fermihubbard` did not take advantage of fermion bitstrings. This PR fixes it.